### PR TITLE
Fix exception when clearing index

### DIFF
--- a/multilingual/elasticsearch_backend.py
+++ b/multilingual/elasticsearch_backend.py
@@ -93,7 +93,7 @@ class ElasticsearchMultilingualSearchBackend(ElasticsearchSearchBackend):
 
         self.setup_complete = True
 
-    def clear(self, models=[], commit=True):
+    def clear(self, models=None, commit=True):
         """
         Clears all indexes for the current project.
         :param models: if specified, only deletes the entries for the given models.


### PR DESCRIPTION
Running python manage.py clear_index or rebuild_index cause exception:

```
(citaty) C:\Users\martin.svoboda\workspace\citaty> python manage.py rebuild_index                                       
                                                                                                                        
WARNING: This will irreparably remove EVERYTHING from your search index in connection 'default'.                        
Your choices after this are to restore from backups or rebuild via the `rebuild_index` command.                         
Are you sure you wish to continue? [y/N] y                                                                              
Removing all documents from your index because you said so.                                                             
Traceback (most recent call last):                                                                                      
  File "manage.py", line 9, in <module>                                                                                 
    execute_from_command_line(sys.argv)                                                                                 
  File "c:\Users\martin.svoboda\workspace\.venv\citaty\lib\site-packages\django\core\management\__init__.py", line 338, 
in execute_from_command_line                                                                                            
    utility.execute()                                                                                                   
  File "c:\Users\martin.svoboda\workspace\.venv\citaty\lib\site-packages\django\core\management\__init__.py", line 330, 
in execute                                                                                                              
    self.fetch_command(subcommand).run_from_argv(self.argv)                                                             
  File "c:\Users\martin.svoboda\workspace\.venv\citaty\lib\site-packages\django\core\management\base.py", line 390, in r
un_from_argv                                                                                                            
    self.execute(*args, **cmd_options)                                                                                  
  File "c:\Users\martin.svoboda\workspace\.venv\citaty\lib\site-packages\django\core\management\base.py", line 441, in e
xecute                                                                                                                  
    output = self.handle(*args, **options)                                                                              
  File "c:\Users\martin.svoboda\workspace\.venv\citaty\lib\site-packages\haystack\management\commands\rebuild_index.py",
 line 25, in handle                                                                                                     
    call_command('clear_index', **options)                                                                              
  File "c:\Users\martin.svoboda\workspace\.venv\citaty\lib\site-packages\django\core\management\__init__.py", line 120, 
in call_command                                                                                                         
    return command.execute(*args, **defaults)                                                                           
  File "c:\Users\martin.svoboda\workspace\.venv\citaty\lib\site-packages\django\core\management\base.py", line 441, in e
xecute                                                                                                                  
    output = self.handle(*args, **options)                                                                              
  File "c:\Users\martin.svoboda\workspace\.venv\citaty\lib\site-packages\haystack\management\commands\clear_index.py", l
ine 56, in handle                                                                                                       
    backend.clear(commit=self.commit)                                                                                   
  File "c:\Users\martin.svoboda\workspace\.venv\citaty\lib\site-packages\multilingual\elasticsearch_backend.py", line 10
5, in clear                                                                                                             
    super(ElasticsearchMultilingualSearchBackend, self).clear(models, commit)                                           
  File "c:\Users\martin.svoboda\workspace\.venv\citaty\lib\site-packages\haystack\backends\elasticsearch_backend.py", li
ne 246, in clear                                                                                                        
    self.conn.delete_by_query(index=self.index_name, doc_type='modelresult', body=query)                                
AttributeError: 'Elasticsearch' object has no attribute 'delete_by_query'                                                                                                                             
```

After fix applying seems all right.