### PR TITLE
Fix tests for running locally

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,4 @@ ipdb
 django-haystack>=2.4.1, <2.5
 django-modeltranslation==0.12.2
 django-parler==1.9.2
+mock==2.0.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,4 @@ psycopg2
 ipdb
 django-haystack>=2.4.1, <2.5
 django-modeltranslation==0.9.1
-django-parler==1.5
+django-parler==1.9.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,5 +4,5 @@ urllib3>=1.10.4
 psycopg2
 ipdb
 django-haystack>=2.4.1, <2.5
-django-modeltranslation==0.9.1
+django-modeltranslation==0.12.2
 django-parler==1.9.2


### PR DESCRIPTION
Closes https://github.com/sbaechler/django-multilingual-search/issues/13.

After this, I can:

```
$ vagrant up
$ pip install -r tests/requirements.txt
$ python tests/manage.py tests
```

And things are working.