### PR TITLE
Specify ElasticSearch version. Use tox for testing.

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+. .venv/bin/activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
 
+dist: trusty
+
 sudo: false
-
-
-services:
-  - elasticsearch
 
 matrix:
   include:
@@ -15,6 +13,9 @@ matrix:
           - elasticsearch-$ELASTICVERSION
         packages:
           - elasticsearch
+
+services:
+  - elasticsearch
 
 install:
   - pip install -U pip tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
 
 install:
   - pip install -U pip tox
-  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/$ELASTICVERSION/elasticsearch-$ELASTICVERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ELASTICVERSION.deb && sudo service elasticsearch restart
 
 before_script:
   - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,17 @@
 language: python
+
 sudo: false
-python:
-  - "2.7"
-  - "3.4"
-services:
-- elasticsearch
+
+matrix:
+  include:
+    env: ELASTICVERSION=1.7.3
+
+install:
+  - pip install -U pip tox
+  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/$ELASTICVERSION/elasticsearch-$ELASTICVERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ELASTICVERSION.deb && sudo service elasticsearch restart
+
 before_script:
   - sleep 10
-env:
-  - DJANGO_REQUIREMENT="Django>=1.6,<1.7"
-  - DJANGO_REQUIREMENT="Django>=1.9,<1.10"
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install:
-  - pip install -q $DJANGO_REQUIREMENT "elasticsearch==1.7.0" "django-haystack==2.4.1" django-modeltranslation django-parler flake8
-  - python setup.py -q install
-# command to run tests, e.g. python setup.py test
 script:
-  - flake8
-  - cd tests
-  - ./manage.py test tests
+  - cd tests && tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,19 @@ language: python
 
 sudo: false
 
+
+services:
+  - elasticsearch
+
 matrix:
   include:
-    env: ELASTICVERSION=1.7.3
+    env: ELASTICVERSION=1.7
+    addons:
+      apt:
+        sources:
+          - elasticsearch-$ELASTICVERSION
+        packages:
+          - elasticsearch
 
 install:
   - pip install -U pip tox


### PR DESCRIPTION
Working on fixing https://github.com/sbaechler/django-multilingual-search/issues/11.

I think it is important to specify which ES version. We can offer which versions are supported then.

I think also, regarding versions of testing dependencies, we should rely on Tox and the environments configured.